### PR TITLE
Whole stack trace is outputted in the headline

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ exports = module.exports = function errorHandler(options) {
               .replace('{stack}', stack)
               .replace('{title}', escapeHtml(exports.title))
               .replace('{statusCode}', res.statusCode)
-              .replace(/\{error\}/g, escapeHtml(str).replace(/  /g, ' &nbsp;').replace(/\n/g, '<br>'))
+              .replace(/\{error\}/g, escapeHtml(String(err)).replace(/  /g, ' &nbsp;').replace(/\n/g, '<br>'))
             res.setHeader('Content-Type', 'text/html; charset=utf-8');
             res.end(html);
         });


### PR DESCRIPTION
When viewing errors as HTML/in browser the whole stack trace is outputted twice. A regression that I believe was introduced in https://github.com/expressjs/errorhandler/commit/9ae818155de261ef9af74a480a35071b8c1951f4