### PR TITLE
The options object accepts a property 'title'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Possible values:
   * `false`: Only send the error back in the response.
   * A function: pass the error to a function for handling.
 
+##### title
+
+Set a custom title to be used as a page header for the template.
+
+The default value for this option is `Connect`.
+
+Possible values:
+
+  * `string`: Set the page header of the template with the string provided.
+
 ## Examples
 
 ### Simple example

--- a/index.js
+++ b/index.js
@@ -83,6 +83,17 @@ exports = module.exports = function errorHandler(options) {
     log = logerror
   }
 
+  // get title option
+  var title = opts.title === undefined
+    ? 'Connect'
+    : opts.title
+
+  if (typeof title !== 'string') {
+    throw new TypeError('option title must be string')
+  }
+
+  exports.title = title
+
   return function errorHandler(err, req, res, next){
     // respect err.statusCode
     if (err.statusCode) {

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,10 @@ describe('errorHandler()', function () {
     .expect(500, done)
   })
 
+  it('should have property title', function() {
+    assert(errorHandler.hasOwnProperty('title'), 'property title doesn\'t exist')
+  })
+
   describe('status code', function () {
     describe('when non-error status code', function () {
       it('should set the status code to 500', function (done) {
@@ -389,6 +393,12 @@ describe('errorHandler(options)', function () {
         .set('Accept', 'text/plain')
         .expect(500, error.stack.toString(), cb)
       })
+    })
+  })
+
+  describe('title', function() {
+    it('should only accept a string', function() {
+      assert.throws(errorHandler.bind(null, {title: true}), /option title must be/)
     })
   })
 })


### PR DESCRIPTION
The options object accepts a property 'title' to set a custom title for the error page, with respect for the existing title property of errorhandler. This property  could be set deprecated for me.

In the future it would be great to pass my 'own' function to the options object that renders a custom error-page.