### PR TITLE
docs: state assumption in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ var errorhandler = require('errorhandler')
 
 var app = connect()
 
+// assumes NODE_ENV is set by the user
 if (process.env.NODE_ENV === 'development') {
   // only use in development
   app.use(errorhandler())
@@ -100,6 +101,7 @@ var notifier = require('node-notifier')
 
 var app = connect()
 
+// assumes NODE_ENV is set by the user
 if (process.env.NODE_ENV === 'development') {
   // only use in development
   app.use(errorhandler({ log: errorNotification }))


### PR DESCRIPTION
This clearly documents the assumption, made by the examples, that the user is setting the `NODE_ENV` environment variable to control their application. While this may be standard practice, clarity in documentation is rarely a bad thing!

Resolves #28 