### PR TITLE
deps: update accepts from 1.3.8 to ~2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://opencollective.com/express"
   },
   "dependencies": {
-    "accepts": "~1.3.8",
+    "accepts": "~2.0.0",
     "escape-html": "~1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Upgrade `accepts` runtime dependency from 1.3.8 to ~2.0.0.

## Motivation

`accepts` v2 upgrades to `negotiator` v1 and `mime-types` v3, bringing the content negotiation stack up to date. The API is fully backward-compatible — no code changes needed.

## Testing

- `npm install` succeeds
- `npm test` passes: **23/23** ✅
- No source code changes required

## Changes

- `package.json`: `"accepts": "~1.3.8"` → `"accepts": "~2.0.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)